### PR TITLE
Only normalize URL if its given. Fixes a crash in resumeDownload

### DIFF
--- a/lib/TaskExecuter.js
+++ b/lib/TaskExecuter.js
@@ -25,7 +25,9 @@ var normalizeUrl = function(url) {
 }
 
 var TaskExecuter = function(file, url, options) {
-	url = normalizeUrl(url)
+	if (url !== null) {
+		url = normalizeUrl(url)
+	}
 
 	this.options = options || {};
 


### PR DESCRIPTION
When calling `mtd.resumeDownload(path)` the `url` argument is null.
The code crashed because calling `null.startsWith()`.

I already tested out the changes and resume is working now like expected.

PS: Nice library ;)